### PR TITLE
fix: change RowFunc params with index

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -145,9 +145,9 @@ func (e *Exporter) exportHelper(sheet SheetData, initFunc func(string) error, wr
 	if err := initFunc(e.CurrentSheet); err != nil {
 		return err
 	}
-
+	var rowIndex = 0
 	for {
-		row, err := sheet.RowFunc(rowID)
+		row, err := sheet.RowFunc(rowIndex)
 		if err != nil {
 			return err
 		}
@@ -177,6 +177,7 @@ func (e *Exporter) exportHelper(sheet SheetData, initFunc func(string) error, wr
 		}
 
 		rowID++
+		rowIndex++
 	}
 
 	return nil

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -24,7 +24,7 @@ func TestExportWithStreamWriter(t *testing.T) {
 	}
 	sheetData3 := SheetData{
 		Name:    "SheetC",
-		RowFunc: generateLargeData("SheetC", 1<<20+1), // 20k rows
+		RowFunc: generateLargeData("SheetC", 1<<20+1),
 	}
 
 	sheets := []SheetData{sheetData1, sheetData2, sheetData3}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -22,8 +22,12 @@ func TestExportWithStreamWriter(t *testing.T) {
 		Name:    "SheetB",
 		RowFunc: generateLargeData("SheetB", 2000), // 2k rows
 	}
+	sheetData3 := SheetData{
+		Name:    "SheetC",
+		RowFunc: generateLargeData("SheetC", 1<<20+1), // 20k rows
+	}
 
-	sheets := []SheetData{sheetData1, sheetData2}
+	sheets := []SheetData{sheetData1, sheetData2, sheetData3}
 
 	// Start CPU profiling
 	cpuProfile, err := os.Create("cpu_profile_streamwriter.prof")


### PR DESCRIPTION
当切片长度超过 1 << 20 + 1, 由于rowId重置会导致死循环